### PR TITLE
Create dockerfile for GAE.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,7 @@ FROM ubuntu
 
 # Install wget, unzip, python2.7
 RUN apt-get update \
-  && apt-get install -y wget \
-  && apt-get install -y unzip \
-  && apt-get install -y python2.7 python-pil -y \
-  && apt-get install -y python-pip \
+  && apt-get install -y wget unzip python2.7 python-pil python-pip \
   && rm -rf /var/lib/apt/lists/*
 
 # Install GAE

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+FROM ubuntu
+
+# Install wget, unzip, python2.7
+RUN apt-get update \
+  && apt-get install -y wget \
+  && apt-get install -y unzip \
+  && apt-get install -y python2.7 python-pil -y \
+  && apt-get install -y python-pip \
+  && rm -rf /var/lib/apt/lists/*
+
+# Install GAE
+RUN wget -O /appengine.zip https://storage.googleapis.com/appengine-sdks/featured/google_appengine_1.9.38.zip
+RUN unzip /appengine.zip -d /appengine && rm /appengine.zip
+
+
+# Copy src files to /app
+RUN mkdir /app
+COPY . /app
+
+# Install dependencies.
+RUN cd /app && pip install -r requirements.txt -t lib
+
+# Expose and start app server.
+EXPOSE 22 8000 8080
+ENTRYPOINT /appengine/google_appengine/dev_appserver.py \
+  --skip_sdk_update_check --host 0.0.0.0 /app/
+

--- a/README.md
+++ b/README.md
@@ -18,3 +18,15 @@ The developer setup is assuming Ubuntu Server 14.04 as a starting point.
 
   4. Start the project with
   `$ /path/to/app_engine/dev_appserver.py --host 0.0.0.0 kegstarter/`
+
+Or You can create a Docker container to run the app. It will install deps and
+start the app server at http://localhost:8080
+```
+$ docker build -t kegstarter <path_to_src>
+$ docker run -d kegstarter
+```
+
+To stop the container, find the container name or id using `docker ps` and
+gracefully stop the server using `docker stop <name|id>`.
+
+


### PR DESCRIPTION
Added a Docker file that followed the README install steps. It's based on a a base ubuntu image, there were several GAE-python images in the Docker-Hub but I thought we could build it from scratch to learn a few things.
